### PR TITLE
[IA-2089] remove atomic install and fix uninstall function

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
   .settings(
     organization := "org.broadinstitute.dsp",
     name := "helm-scala-sdk",
-    version := "0.0.1-RC1",
+    version := "0.0.1-rt-uninstall-SNAPSHOT",
     scalaVersion := "2.13.2",
     crossScalaVersions := List("2.12.10", "2.13.2"),
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
   .settings(
     organization := "org.broadinstitute.dsp",
     name := "helm-scala-sdk",
-    version := "0.0.1-rt-uninstall-SNAPSHOT",
+    version := "0.0.1-RC1",
     scalaVersion := "2.13.2",
     crossScalaVersions := List("2.12.10", "2.13.2"),
     libraryDependencies ++= Seq(

--- a/helm-go-lib/main.go
+++ b/helm-go-lib/main.go
@@ -148,7 +148,7 @@ func installChart(namespace string, kubeToken string, apiServer string, caFile s
 }
 
 //export uninstallRelease
-func uninstallRelease(namespace string, kubeToken string, apiServer string, caFile string, releaseName string) *C.char {
+func uninstallRelease(namespace string, kubeToken string, apiServer string, caFile string, releaseName string, keepHistory bool) *C.char {
 	actionConfig, err := buildActionConfig(namespace, kubeToken, apiServer, caFile)
 	if err != nil {
 		log.Printf("%+v\n", err)
@@ -156,6 +156,8 @@ func uninstallRelease(namespace string, kubeToken string, apiServer string, caFi
 	}
 
 	client := action.NewUninstall(actionConfig)
+	client.KeepHistory = keepHistory
+
 	_, err = client.Run(releaseName)
 	if err != nil {
 		log.Printf("%+v\n", err)

--- a/helm-go-lib/main.go
+++ b/helm-go-lib/main.go
@@ -16,8 +16,8 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/getter"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 /*
@@ -99,7 +99,6 @@ func installChart(namespace string, kubeToken string, apiServer string, caFile s
 	client.DependencyUpdate = true
 	client.Namespace = namespace
 	client.ReleaseName = releaseName
-	client.Atomic = true
 	//client.DryRun = true
 
 	settings := cli.New()
@@ -116,7 +115,8 @@ func installChart(namespace string, kubeToken string, apiServer string, caFile s
 	chartRequested, err := loader.Load(cp)
 	if err != nil {
 		log.Printf("%+v", err)
-		return C.CString(err.Error())	}
+		return C.CString(err.Error())
+	}
 
 	// Adapted from the example below to override chart values as in CLI --set
 	// https://github.com/PrasadG193/helm-clientgo-example
@@ -127,7 +127,8 @@ func installChart(namespace string, kubeToken string, apiServer string, caFile s
 	values, err := valueOpts.MergeValues(providers)
 	if err != nil {
 		log.Printf("%+v", err)
-		return C.CString(err.Error())	}
+		return C.CString(err.Error())
+	}
 
 	// Add --set overrides in the form of comma-separated key=value pairs
 	if err := strvals.ParseInto(overrideValues, values); err != nil {

--- a/src/main/scala/org/broadinstitute/dsp/HelmAlgebra.scala
+++ b/src/main/scala/org/broadinstitute/dsp/HelmAlgebra.scala
@@ -15,7 +15,9 @@ trait HelmAlgebra[F[_]] {
 
   def listHelm(): Kleisli[F, AuthContext, Unit]
 
-  def uninstall(release: Release): Kleisli[F, AuthContext, Unit]
+  // Set keepHistory to true to make helm retain a record to the release which can make debuggingg easier.
+  // https://helm.sh/docs/intro/using_helm/#helm-uninstall-uninstalling-a-release
+  def uninstall(release: Release, keepHistory: Boolean = false): Kleisli[F, AuthContext, Unit]
 }
 
 final case class HelmException(message: String) extends NoStackTrace {

--- a/src/main/scala/org/broadinstitute/dsp/HelmAlgebra.scala
+++ b/src/main/scala/org/broadinstitute/dsp/HelmAlgebra.scala
@@ -15,7 +15,7 @@ trait HelmAlgebra[F[_]] {
 
   def listHelm(): Kleisli[F, AuthContext, Unit]
 
-  def uninstall(): Kleisli[F, AuthContext, Unit]
+  def uninstall(release: Release): Kleisli[F, AuthContext, Unit]
 }
 
 final case class HelmException(message: String) extends NoStackTrace {

--- a/src/main/scala/org/broadinstitute/dsp/HelmInterpreter.scala
+++ b/src/main/scala/org/broadinstitute/dsp/HelmInterpreter.scala
@@ -54,7 +54,7 @@ class HelmInterpreter[F[_]: ContextShift](blocker: Blocker, concurrencyBound: Se
       _ <- Kleisli.liftF(translateResult("helm list", "ok"))
     } yield ()
 
-  override def uninstall(release: Release): Kleisli[F, AuthContext, Unit] =
+  override def uninstall(release: Release, keepHistory: Boolean): Kleisli[F, AuthContext, Unit] =
     for {
       ctx <- Kleisli.ask[F, AuthContext]
       _ <- Kleisli.liftF(
@@ -65,7 +65,8 @@ class HelmInterpreter[F[_]: ContextShift](blocker: Blocker, concurrencyBound: Se
               ctx.kubeToken,
               ctx.kubeApiServer,
               ctx.caCertFile,
-              release
+              release,
+              keepHistory
             )
           )
         )

--- a/src/main/scala/org/broadinstitute/dsp/HelmInterpreter.scala
+++ b/src/main/scala/org/broadinstitute/dsp/HelmInterpreter.scala
@@ -54,7 +54,7 @@ class HelmInterpreter[F[_]: ContextShift](blocker: Blocker, concurrencyBound: Se
       _ <- Kleisli.liftF(translateResult("helm list", "ok"))
     } yield ()
 
-  override def uninstall(): Kleisli[F, AuthContext, Unit] =
+  override def uninstall(release: Release): Kleisli[F, AuthContext, Unit] =
     for {
       ctx <- Kleisli.ask[F, AuthContext]
       _ <- Kleisli.liftF(
@@ -64,13 +64,13 @@ class HelmInterpreter[F[_]: ContextShift](blocker: Blocker, concurrencyBound: Se
               ctx.namespace,
               ctx.kubeToken,
               ctx.kubeApiServer,
-              ctx.caCertFile
+              ctx.caCertFile,
+              release
             )
           )
         )
       )
-      // TODO: Make 'helm uninstall' return String
-      _ <- Kleisli.liftF(translateResult("helm list", "ok"))
+      _ <- Kleisli.liftF(translateResult("helm uninstall", "ok"))
     } yield ()
 
   private def translateResult(cmd: String, result: String): F[Unit] = result match {

--- a/src/main/scala/org/broadinstitute/dsp/HelmJnaClient.java
+++ b/src/main/scala/org/broadinstitute/dsp/HelmJnaClient.java
@@ -48,7 +48,8 @@ public interface HelmJnaClient extends Library {
           GoString.ByValue namespace,
           GoString.ByValue kubeToken,
           GoString.ByValue kubeApiServer,
-          GoString.ByValue caCertFile
+          GoString.ByValue caCertFile,
+          GoString.ByValue release
   );
 
   public void listHelm(GoString.ByValue namespace,

--- a/src/main/scala/org/broadinstitute/dsp/HelmJnaClient.java
+++ b/src/main/scala/org/broadinstitute/dsp/HelmJnaClient.java
@@ -49,7 +49,8 @@ public interface HelmJnaClient extends Library {
           GoString.ByValue kubeToken,
           GoString.ByValue kubeApiServer,
           GoString.ByValue caCertFile,
-          GoString.ByValue release
+          GoString.ByValue release,
+          byte keepHistory
   );
 
   public void listHelm(GoString.ByValue namespace,

--- a/src/main/scala/org/broadinstitute/dsp/implicits.scala
+++ b/src/main/scala/org/broadinstitute/dsp/implicits.scala
@@ -20,4 +20,7 @@ object implicits {
     goString.n = a.show.length
     goString
   }
+
+  implicit def toGoBool(b: Boolean): Byte =
+    if (b) 1 else 0
 }

--- a/src/test/scala/org/broadinstitute/dsp/HelmManualTest.scala
+++ b/src/test/scala/org/broadinstitute/dsp/HelmManualTest.scala
@@ -44,4 +44,10 @@ final class HelmManualTest(namespace: String, token: String, apiServer: String, 
       .listHelm()
       .run(authContext)
       .unsafeRunSync()
+
+  def callUninstall(release: String): Unit =
+    helmClient
+      .uninstall(Release(release))
+      .run(authContext)
+      .unsafeRunSync()
 }

--- a/src/test/scala/org/broadinstitute/dsp/HelmManualTest.scala
+++ b/src/test/scala/org/broadinstitute/dsp/HelmManualTest.scala
@@ -45,9 +45,9 @@ final class HelmManualTest(namespace: String, token: String, apiServer: String, 
       .run(authContext)
       .unsafeRunSync()
 
-  def callUninstall(release: String): Unit =
+  def callUninstall(release: String, keepHistory: Boolean): Unit =
     helmClient
-      .uninstall(Release(release))
+      .uninstall(Release(release), keepHistory)
       .run(authContext)
       .unsafeRunSync()
 }

--- a/src/test/scala/org/broadinstitute/dsp/mocks/MockHelm.scala
+++ b/src/test/scala/org/broadinstitute/dsp/mocks/MockHelm.scala
@@ -10,7 +10,7 @@ class MockHelm extends HelmAlgebra[IO] {
 
   override def listHelm(): Kleisli[IO, AuthContext, Unit] = Kleisli.pure(())
 
-  override def uninstall(): Kleisli[IO, AuthContext, Unit] = Kleisli.pure(())
+  override def uninstall(release: Release): Kleisli[IO, AuthContext, Unit] = Kleisli.pure(())
 }
 
 object MockHelm extends MockHelm

--- a/src/test/scala/org/broadinstitute/dsp/mocks/MockHelm.scala
+++ b/src/test/scala/org/broadinstitute/dsp/mocks/MockHelm.scala
@@ -10,7 +10,7 @@ class MockHelm extends HelmAlgebra[IO] {
 
   override def listHelm(): Kleisli[IO, AuthContext, Unit] = Kleisli.pure(())
 
-  override def uninstall(release: Release): Kleisli[IO, AuthContext, Unit] = Kleisli.pure(())
+  override def uninstall(release: Release, keepHistory: Boolean): Kleisli[IO, AuthContext, Unit] = Kleisli.pure(())
 }
 
 object MockHelm extends MockHelm


### PR DESCRIPTION
1. `client.Atomic = true` was causing the Go client to poll pods for completion after the helm install command. I'd rather it be asynchronous and use Leo scala code for polling.

2. `uninstall` function wasn't quite working -- fixed it up. Also added `keepHistory` param