### PR TITLE
IA-2052 IA-2564 add createNamespace flag to helm install

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ lazy val root = (project in file("."))
   .settings(
     organization := "org.broadinstitute.dsp",
     name := "helm-scala-sdk",
-    version := "0.0.1-RC4",
-    scalaVersion := "2.13.2",
-    crossScalaVersions := List("2.12.10", "2.13.2"),
+    version := "0.0.1-RC5",
+    scalaVersion := "2.13.4",
+    crossScalaVersions := List("2.12.10", "2.13.4"),
     libraryDependencies ++= Seq(
       "net.java.dev.jna" % "jna" % "5.5.0",
       "co.fs2" %% "fs2-core" % "2.3.0",
@@ -27,7 +27,7 @@ scalacOptions ++= Seq(
   "-encoding", "UTF-8",
   "-language:higherKinds",
   "-language:postfixOps",
-  "-feature",
+  "-feature"
 //  "-Xfatal-warnings"
 )
 

--- a/helm-go-lib/main.go
+++ b/helm-go-lib/main.go
@@ -59,6 +59,7 @@ func main() {
 		chartName,
 		chartVersion,
 		overrideValues,
+		true,
 	)
 
 	glog.Flush()

--- a/helm-go-lib/main.go
+++ b/helm-go-lib/main.go
@@ -5,10 +5,11 @@ import "C"
 import (
 	"flag"
 	"fmt"
-	"helm.sh/helm/v3/pkg/strvals"
 	"log"
 	"os"
 	"strings"
+
+	"helm.sh/helm/v3/pkg/strvals"
 
 	"github.com/golang/glog"
 	"helm.sh/helm/v3/pkg/action"
@@ -89,7 +90,7 @@ func listHelm(namespace string, kubeToken string, apiServer string, caFile strin
 // TODO: Do we need to make 'overrideValues' optional?
 // TODO: If so, emulate it (perhaps via variadic functions) since Golang doesn't support optional parameters :(
 // `HELM_DRIVER` env variable is expected to have been set to the right value (which is likely to be "secret")
-func installChart(namespace string, kubeToken string, apiServer string, caFile string, releaseName string, chartName string, chartVersion string, overrideValues string) *C.char {
+func installChart(namespace string, kubeToken string, apiServer string, caFile string, releaseName string, chartName string, chartVersion string, overrideValues string, createNamespace bool) *C.char {
 	actionConfig, err := buildActionConfig(namespace, kubeToken, apiServer, caFile)
 	if err != nil {
 		log.Printf("%+v\n", err)
@@ -102,7 +103,7 @@ func installChart(namespace string, kubeToken string, apiServer string, caFile s
 	client.Version = chartVersion
 	client.Namespace = namespace
 	client.ReleaseName = releaseName
-	//client.DryRun = true
+	client.CreateNamespace = createNamespace
 
 	settings := cli.New()
 	settings.KubeToken = kubeToken

--- a/src/main/scala/org/broadinstitute/dsp/HelmAlgebra.scala
+++ b/src/main/scala/org/broadinstitute/dsp/HelmAlgebra.scala
@@ -11,7 +11,8 @@ trait HelmAlgebra[F[_]] {
     release: Release,
     chartName: ChartName,
     chartVersion: ChartVersion,
-    values: Values
+    values: Values,
+    createNamespace: Boolean = false
   ): Kleisli[F, AuthContext, Unit]
 
   def listHelm(): Kleisli[F, AuthContext, Unit]

--- a/src/main/scala/org/broadinstitute/dsp/HelmInterpreter.scala
+++ b/src/main/scala/org/broadinstitute/dsp/HelmInterpreter.scala
@@ -15,7 +15,7 @@ class HelmInterpreter[F[_]: ContextShift](blocker: Blocker, concurrencyBound: Se
 
   val helmClient = Native.load("helm", classOf[HelmJnaClient])
 
-  override def installChart(release: Release, chartName: ChartName, chartVersion: ChartVersion, values: Values): Kleisli[F, AuthContext, Unit] =
+  override def installChart(release: Release, chartName: ChartName, chartVersion: ChartVersion, values: Values, createNamespace: Boolean = false): Kleisli[F, AuthContext, Unit] =
     for {
       ctx <- Kleisli.ask[F, AuthContext]
       r <- Kleisli.liftF(
@@ -29,7 +29,8 @@ class HelmInterpreter[F[_]: ContextShift](blocker: Blocker, concurrencyBound: Se
               release,
               chartName,
               chartVersion,
-              values
+              values,
+              createNamespace
             )
           )
         )

--- a/src/main/scala/org/broadinstitute/dsp/HelmJnaClient.java
+++ b/src/main/scala/org/broadinstitute/dsp/HelmJnaClient.java
@@ -42,7 +42,8 @@ public interface HelmJnaClient extends Library {
              GoString.ByValue release,
              GoString.ByValue chartName,
              GoString.ByValue chartVersion,
-             GoString.ByValue values
+             GoString.ByValue values,
+             byte createNamespace
            );
 
   public String uninstallRelease(

--- a/src/test/scala/org/broadinstitute/dsp/mocks/MockHelm.scala
+++ b/src/test/scala/org/broadinstitute/dsp/mocks/MockHelm.scala
@@ -5,7 +5,7 @@ import cats.effect.IO
 import org.broadinstitute.dsp.{AuthContext, ChartName, ChartVersion, HelmAlgebra, Release, Values}
 
 class MockHelm extends HelmAlgebra[IO] {
-  override def installChart(release: Release, chartName: ChartName, chartVersion: ChartVersion, values: Values): Kleisli[IO, AuthContext, Unit] =
+  override def installChart(release: Release, chartName: ChartName, chartVersion: ChartVersion, values: Values, createNamespace: Boolean = false): Kleisli[IO, AuthContext, Unit] =
     Kleisli.pure(())
 
   override def listHelm(): Kleisli[IO, AuthContext, Unit] = Kleisli.pure(())


### PR DESCRIPTION
Tested in leo. Notice this adds `name` label properly as well.
It doesn't seem like helm allows adding random labels, but it does add `name` label automatically

```
➜  workspace kubectl describe namespace nginx                                                                                                                                                                                                                 [21/03/4| 9:01AM]
Name:         nginx
Labels:       name=nginx
Annotations:  <none>
Status:       Active
```