### PR TITLE
[IA-4165] build library from java 17 to be compatible with leo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Publish locally
 
 Publish to JFrog
 Before running the publishing command, make sure to bump the package version in built.sbt.
+Make sure to compile/publish with Java 17, this is what leonardo expects!
 You can then find the artifactory credentials on vault (`secret/dsp/accts/artifactory/dsdejenkins`).
 Export both ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to your environment.
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file("."))
   .settings(
     organization := "org.broadinstitute.dsp",
     name := "helm-scala-sdk",
-    version := "0.0.5",
+    version := "0.0.7",
     scalaVersion := "2.13.6",
     crossScalaVersions := List("2.13.6"),
     libraryDependencies ++= Seq(


### PR DESCRIPTION
Rookie mistake, but I added warnings in the Readme to make sure that devs are compiling / publishing using the same java version as leonardo (aka 17).
Took me a couple of oopsies so 0.05 and 0.06 are no good, but leo build and fiab start jenkins jobs were successful for leo with 0.0.7 https://github.com/DataBiosphere/leonardo/pull/3327