### PR TITLE
Update JNA version to 5.13.0 to enable support for M1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ lazy val root = (project in file("."))
   .settings(
     organization := "org.broadinstitute.dsp",
     name := "helm-scala-sdk",
-    version := "0.0.7",
+    version := "0.0.8",
     scalaVersion := "2.13.6",
     crossScalaVersions := List("2.13.6"),
     libraryDependencies ++= Seq(
-      "net.java.dev.jna" % "jna" % "5.5.0",
+      "net.java.dev.jna" % "jna" % "5.13.0",
       "co.fs2" %% "fs2-core" % "3.0.6",
       "org.typelevel" %% "log4cats-slf4j"   % "2.1.1",
       "org.scalatest" %% "scalatest" % "3.3.0-SNAP2" % Test


### PR DESCRIPTION
Newer JNA supports M1, which allows us to run things which depend on this library outside of a docker container, if desired. Tested with local Leo (which I'm working on rn) and these changes (+ local publish) solved my issues.